### PR TITLE
Fix/stronger token handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,5 +43,5 @@ libraryDependencies ++= Seq(
   "org.reactivemongo" %% "reactivemongo" % "0.11.14",
   "com.github.melrief" %% "pureconfig" % "0.1.6",
   "org.reactivemongo" %% "play2-reactivemongo" % "0.11.14",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.0-RC1" % Test
+  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.0" % Test
 )

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,6 @@ test:
   override:
     - sbt coverage test:test
   post:
-    - sbt coverageReport coverageAggregate
+    - sbt coverageReport coverageAggregate codacyCoverage
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/target/test-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/src/main/scala/uk.gov.bis/levyApiMock/actions/AuthorizedAction.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/actions/AuthorizedAction.scala
@@ -1,12 +1,13 @@
 package uk.gov.bis.levyApiMock.actions
 
 import cats.data.OptionT
+import cats.instances.future._
+import cats.instances.string._
+import cats.syntax.eq._
 import com.google.inject.Inject
-import play.api.Logger
+import uk.gov.bis.levyApiMock.auth.OAuthTrace
 import uk.gov.bis.levyApiMock.data.GatewayUserOps
 import uk.gov.bis.levyApiMock.data.oauth2.{AuthRecord, AuthRecordOps}
-import cats.instances.future._
-import uk.gov.bis.levyApiMock.auth.OAuthTrace
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -17,13 +18,12 @@ class AuthorizedAction @Inject()(authRecords: AuthRecordOps, users: GatewayUserO
   def apply(empref: String): AuthAction = new AuthorizedActionBuilder(empref, authRecords, users)
 }
 
-
 class AuthorizedActionBuilder(empref: String, authRecords: AuthRecordOps, users: GatewayUserOps)(implicit val ec: ExecutionContext) extends AuthAction {
   override def validateToken(accessToken: String): Future[Option[AuthRecord]] = {
     OAuthTrace(s"looking for auth record for access token $accessToken")
 
     for {
-      ar <- OptionT(authRecords.find(accessToken))
+      ar <- OptionT(authRecords.find(accessToken)) if !ar.accessTokenExpired(System.currentTimeMillis())
       _ = OAuthTrace(s"found auth record $ar")
       hasAccess <- OptionT.liftF(checkAccess(ar)) if hasAccess
     } yield ar
@@ -31,6 +31,6 @@ class AuthorizedActionBuilder(empref: String, authRecords: AuthRecordOps, users:
 
   private def checkAccess(ar: AuthRecord): Future[Boolean] = {
     if (ar.isPrivileged) Future.successful(true)
-    else users.forGatewayID(ar.gatewayID).map(_.exists(_.empref == empref))
+    else users.forGatewayID(ar.gatewayID).map(_.exists(_.empref === empref))
   }
 }

--- a/src/main/scala/uk.gov.bis/levyApiMock/actions/AuthorizedAction.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/actions/AuthorizedAction.scala
@@ -2,28 +2,26 @@ package uk.gov.bis.levyApiMock.actions
 
 import cats.data.OptionT
 import cats.instances.future._
-import cats.instances.string._
-import cats.syntax.eq._
 import com.google.inject.Inject
 import uk.gov.bis.levyApiMock.auth.OAuthTrace
-import uk.gov.bis.levyApiMock.data.GatewayUserOps
 import uk.gov.bis.levyApiMock.data.oauth2.{AuthRecord, AuthRecordOps}
+import uk.gov.bis.levyApiMock.data.{GatewayUserOps, TimeSource}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * an AuthorizedAction must both have a valid access token and that token must allow access to the given empref
   */
-class AuthorizedAction @Inject()(authRecords: AuthRecordOps, users: GatewayUserOps)(implicit executionContext: ExecutionContext) {
-  def apply(empref: String): AuthAction = new AuthorizedActionBuilder(empref, authRecords, users)
+class AuthorizedAction @Inject()(authRecords: AuthRecordOps, users: GatewayUserOps, timeSource: TimeSource)(implicit executionContext: ExecutionContext) {
+  def apply(empref: String): AuthAction = new AuthorizedActionBuilder(empref, authRecords, users, timeSource)
 }
 
-class AuthorizedActionBuilder(empref: String, authRecords: AuthRecordOps, users: GatewayUserOps)(implicit val ec: ExecutionContext) extends AuthAction {
+class AuthorizedActionBuilder(empref: String, authRecords: AuthRecordOps, users: GatewayUserOps, timeSource: TimeSource)(implicit val ec: ExecutionContext) extends AuthAction {
   override def validateToken(accessToken: String): Future[Option[AuthRecord]] = {
     OAuthTrace(s"looking for auth record for access token $accessToken")
 
     for {
-      ar <- OptionT(authRecords.find(accessToken)) if !ar.accessTokenExpired(System.currentTimeMillis())
+      ar <- OptionT(authRecords.find(accessToken)) if !ar.accessTokenExpired(timeSource.currentTimeMillis())
       _ = OAuthTrace(s"found auth record $ar")
       hasAccess <- OptionT.liftF(checkAccess(ar)) if hasAccess
     } yield ar
@@ -31,6 +29,6 @@ class AuthorizedActionBuilder(empref: String, authRecords: AuthRecordOps, users:
 
   private def checkAccess(ar: AuthRecord): Future[Boolean] = {
     if (ar.isPrivileged) Future.successful(true)
-    else users.forGatewayID(ar.gatewayID).map(_.exists(_.empref === empref))
+    else users.forGatewayID(ar.gatewayID).map(_.exists(_.empref == empref))
   }
 }

--- a/src/main/scala/uk.gov.bis/levyApiMock/actions/AuthorizedAction.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/actions/AuthorizedAction.scala
@@ -18,7 +18,7 @@ class AuthorizedAction @Inject()(authRecords: AuthRecordOps, users: GatewayUserO
 
 class AuthorizedActionBuilder(empref: String, authRecords: AuthRecordOps, users: GatewayUserOps, timeSource: TimeSource)(implicit val ec: ExecutionContext) extends AuthAction {
   override def validateToken(accessToken: String): Future[Option[AuthRecord]] = {
-    OAuthTrace(s"looking for auth record for access token $accessToken")
+    OAuthTrace(s"looking for auth record for access token `$accessToken`")
 
     for {
       ar <- OptionT(authRecords.find(accessToken)) if !ar.accessTokenExpired(timeSource.currentTimeMillis())

--- a/src/main/scala/uk.gov.bis/levyApiMock/auth/APIDataHandler.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/auth/APIDataHandler.scala
@@ -89,7 +89,7 @@ class APIDataHandler @Inject()(
         val updatedRow = authRecord.copy(accessToken = generateToken, refreshToken = Some(generateToken), createdAt = createdAt)
         for {
           _ <- authRecords.deleteExistingAndCreate(authRecord, updatedRow)
-        } yield AccessToken(updatedRow.accessToken, Some(refreshToken), authInfo.scope, accessTokenExpiresIn, new Date(createdAt))
+        } yield AccessToken(updatedRow.accessToken, updatedRow.refreshToken, authInfo.scope, accessTokenExpiresIn, new Date(createdAt))
       case None =>
         val s = s"Cannot find an access token entry with refresh token $refreshToken"
         Logger.warn(s)

--- a/src/main/scala/uk.gov.bis/levyApiMock/auth/APIDataHandler.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/auth/APIDataHandler.scala
@@ -86,9 +86,9 @@ class APIDataHandler @Inject()(
 
     authRecords.forRefreshToken(refreshToken).flatMap {
       case Some(authRecord) =>
-        val updatedRow = authRecord.copy(accessToken = accessToken, createdAt = createdAt)
+        val updatedRow = authRecord.copy(accessToken = generateToken, refreshToken = Some(generateToken), createdAt = createdAt)
         for {
-          _ <- authRecords.deleteExistingAndCreate(updatedRow)
+          _ <- authRecords.deleteExistingAndCreate(authRecord, updatedRow)
         } yield AccessToken(updatedRow.accessToken, Some(refreshToken), authInfo.scope, accessTokenExpiresIn, new Date(createdAt))
       case None =>
         val s = s"Cannot find an access token entry with refresh token $refreshToken"

--- a/src/main/scala/uk.gov.bis/levyApiMock/auth/TOTP.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/auth/TOTP.scala
@@ -7,6 +7,7 @@ import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
 import org.apache.commons.codec.binary.Base32
+import uk.gov.bis.levyApiMock.data.{SystemTimeSource, TimeSource}
 
 import scala.math._
 
@@ -23,7 +24,7 @@ case class TimeWindow(value: Long) extends AnyVal {
 object TimeWindow {
   def forTimestamp(ts: Long): TimeWindow = TimeWindow(ts / 30000)
 
-  def forNow: TimeWindow = forTimestamp(System.currentTimeMillis())
+  def forNow(timeSource: TimeSource = new SystemTimeSource): TimeWindow = forTimestamp(timeSource.currentTimeMillis())
 
   /**
     * Generate three time windows  - one for the given timestamp and the

--- a/src/main/scala/uk.gov.bis/levyApiMock/auth/TOTPGenerator.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/auth/TOTPGenerator.scala
@@ -2,5 +2,5 @@ package uk.gov.bis.levyApiMock.auth
 
 object TOTPGenerator extends App {
   if (args.length < 1) println("Secret is missing.")
-  else println(TOTP.generateCode(args(0), TimeWindow.forNow).value)
+  else println(TOTP.generateCode(args(0), TimeWindow.forNow()).value)
 }

--- a/src/main/scala/uk.gov.bis/levyApiMock/controllers/security/ClaimAuthController.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/controllers/security/ClaimAuthController.scala
@@ -10,7 +10,7 @@ import uk.gov.bis.levyApiMock.data._
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ClaimAuthController @Inject()(scopes: ScopeOps, authIds: AuthRequestOps, clients: ClientOps)(implicit ec: ExecutionContext) extends Controller {
+class ClaimAuthController @Inject()(scopes: ScopeOps, authIds: AuthRequestOps, clients: ClientOps, timeSource: TimeSource)(implicit ec: ExecutionContext) extends Controller {
 
   implicit class ErrorSyntax[A](ao: Option[A]) {
     def orError(err: String): Either[String, A] = ao.fold[Either[String, A]](Left(err))(a => Right(a))
@@ -24,7 +24,7 @@ class ClaimAuthController @Inject()(scopes: ScopeOps, authIds: AuthRequestOps, c
       val authIdOrError = for {
         _ <- EitherT(clients.forId(clientId).map(_.orError("unknown client id")))
         _ <- EitherT(scopes.byName(scopeName).map(_.orError("unknown scope")))
-      } yield AuthRequest(scopeName, clientId, redirectUri, state)
+      } yield AuthRequest(scopeName, clientId, redirectUri, state, 0, MongoDate.fromLong(timeSource.currentTimeMillis()))
 
 
       authIdOrError.value.flatMap {

--- a/src/main/scala/uk.gov.bis/levyApiMock/data/AuthRequestOps.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/data/AuthRequestOps.scala
@@ -2,7 +2,7 @@ package uk.gov.bis.levyApiMock.data
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class AuthRequest(scope: String, clientId: String, redirectUri: String, state: Option[String], id: Long = 0, creationDate: MongoDate = System.currentTimeMillis())
+case class AuthRequest(scope: String, clientId: String, redirectUri: String, state: Option[String], id: Long, creationDate: MongoDate)
 
 trait AuthRequestOps {
   /**

--- a/src/main/scala/uk.gov.bis/levyApiMock/data/oauth2/AuthRecordOps.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/data/oauth2/AuthRecordOps.scala
@@ -14,9 +14,11 @@ case class AuthRecord(
                        createdAt: MongoDate,
                        clientID: String,
                        privileged: Option[Boolean]) {
-  val expiresAt: Long = createdAt.longValue + expiresIn
+  val expiresAt: Long = createdAt.longValue + expiresIn * 1000L
   val expiresAtDateString: String = DateTimeFormat.forPattern("dd/MM/yyyy HH:mm:ss ZZ").print(expiresAt)
   val isPrivileged: Boolean = privileged.getOrElse(false)
+
+  def accessTokenExpired(referenceTimeInMills: Long): Boolean = expiresAt > referenceTimeInMills
 }
 
 trait AuthRecordOps {

--- a/src/main/scala/uk.gov.bis/levyApiMock/data/oauth2/AuthRecordOps.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/data/oauth2/AuthRecordOps.scala
@@ -1,6 +1,7 @@
 package uk.gov.bis.levyApiMock.data.oauth2
 
 import org.joda.time.format.DateTimeFormat
+import uk.gov.bis.levyApiMock.auth.OAuthTrace
 import uk.gov.bis.levyApiMock.data.MongoDate
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -18,7 +19,7 @@ case class AuthRecord(
   val expiresAtDateString: String = DateTimeFormat.forPattern("dd/MM/yyyy HH:mm:ss ZZ").print(expiresAt)
   val isPrivileged: Boolean = privileged.getOrElse(false)
 
-  def accessTokenExpired(referenceTimeInMills: Long): Boolean = expiresAt > referenceTimeInMills
+  def accessTokenExpired(referenceTimeInMills: Long): Boolean = expiresAt <= referenceTimeInMills
 }
 
 trait AuthRecordOps {

--- a/src/main/scala/uk.gov.bis/levyApiMock/data/oauth2/AuthRecordOps.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/data/oauth2/AuthRecordOps.scala
@@ -32,5 +32,5 @@ trait AuthRecordOps {
 
   def create(record: AuthRecord)(implicit ec: ExecutionContext): Future[Unit]
 
-  def deleteExistingAndCreate(token: AuthRecord)(implicit ec: ExecutionContext): Future[Unit]
+  def deleteExistingAndCreate(existing: AuthRecord, created: AuthRecord)(implicit ec: ExecutionContext): Future[Unit]
 }

--- a/src/main/scala/uk.gov.bis/levyApiMock/filters/LoggingFilter.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/filters/LoggingFilter.scala
@@ -5,19 +5,20 @@ import javax.inject.Inject
 import akka.stream.Materializer
 import play.api.Logger
 import play.api.mvc._
+import uk.gov.bis.levyApiMock.data.TimeSource
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class LoggingFilter @Inject()(implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
+class LoggingFilter @Inject()(timeSource: TimeSource)(implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
 
   def apply(nextFilter: RequestHeader => Future[Result])
            (requestHeader: RequestHeader): Future[Result] = {
 
-    val startTime = System.currentTimeMillis
+    val startTime = timeSource.currentTimeMillis()
 
     nextFilter(requestHeader).map { result =>
 
-      val endTime = System.currentTimeMillis
+      val endTime = timeSource.currentTimeMillis()
       val requestTime = endTime - startTime
 
       Logger.info(s"${requestHeader.method} ${requestHeader.uri} took ${requestTime}ms and returned ${result.header.status}")

--- a/src/main/scala/uk.gov.bis/levyApiMock/mongo/AuthCodeMongo.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/mongo/AuthCodeMongo.scala
@@ -5,11 +5,11 @@ import javax.inject.Inject
 import play.api.libs.json.Json
 import play.modules.reactivemongo.ReactiveMongoApi
 import reactivemongo.play.json._
-import uk.gov.bis.levyApiMock.data.{AuthCodeOps, AuthCodeRow}
+import uk.gov.bis.levyApiMock.data.{AuthCodeOps, AuthCodeRow, TimeSource}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AuthCodeMongo @Inject()(val mongodb: ReactiveMongoApi) extends MongoCollection[AuthCodeRow] with AuthCodeOps {
+class AuthCodeMongo @Inject()(val mongodb: ReactiveMongoApi, timeSource: TimeSource) extends MongoCollection[AuthCodeRow] with AuthCodeOps {
   implicit val fmt = Json.format[AuthCodeRow]
 
   override val collectionName: String = "sys_auth_codes"
@@ -24,7 +24,7 @@ class AuthCodeMongo @Inject()(val mongodb: ReactiveMongoApi) extends MongoCollec
   }
 
   override def create(code: String, gatewayUserId: String, redirectUri: String, clientId: String, scope: String)(implicit ec: ExecutionContext): Future[Int] = {
-    val row = AuthCodeRow(code, gatewayUserId, redirectUri, System.currentTimeMillis(), Some("read:apprenticeship-levy"), Some(clientId), 3600)
+    val row = AuthCodeRow(code, gatewayUserId, redirectUri, timeSource.currentTimeMillis(), Some("read:apprenticeship-levy"), Some(clientId), 3600)
     for {
       coll <- collectionF
       i <- coll.insert(row)

--- a/src/main/scala/uk.gov.bis/levyApiMock/mongo/AuthRecordMongo.scala
+++ b/src/main/scala/uk.gov.bis/levyApiMock/mongo/AuthRecordMongo.scala
@@ -5,6 +5,7 @@ import javax.inject.Inject
 import play.api.libs.json._
 import play.modules.reactivemongo.ReactiveMongoApi
 import reactivemongo.play.json._
+import uk.gov.bis.levyApiMock.auth.OAuthTrace
 import uk.gov.bis.levyApiMock.data.oauth2.{AuthRecord, AuthRecordOps}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -30,11 +31,12 @@ class AuthRecordMongo @Inject()(val mongodb: ReactiveMongoApi) extends MongoColl
     } yield ()
   }
 
-  override def deleteExistingAndCreate(auth: AuthRecord)(implicit ec: ExecutionContext): Future[Unit] = {
+  override def deleteExistingAndCreate(existing: AuthRecord, created: AuthRecord)(implicit ec: ExecutionContext): Future[Unit] = {
+    OAuthTrace(s"Removing ${existing.accessToken} and creating ${created.accessToken}")
     for {
       coll <- collectionF
-      _ <- coll.remove(Json.obj("accessToken" -> auth.accessToken))
-      _ <- coll.insert(auth)
+      _ <- coll.remove(Json.obj("accessToken" -> existing.accessToken))
+      _ <- coll.insert(created)
     } yield ()
   }
 }

--- a/src/test/scala/uk/gov/bis/levyApiMock/actions/AuthorizedActionBuilderTest.scala
+++ b/src/test/scala/uk/gov/bis/levyApiMock/actions/AuthorizedActionBuilderTest.scala
@@ -16,9 +16,9 @@ class AuthorizedActionBuilderTest extends WordSpecLike with Matchers with Option
   private val testUser = GatewayUser(testUsername, "", empref1, None, None)
 
   private val nonPrivilegedToken = "12334567890"
-  private val nonPrivilegedAuthRecord = AuthRecord(nonPrivilegedToken, None, testUsername, None, 0, System.currentTimeMillis(), "", Some(false))
+  private val nonPrivilegedAuthRecord = AuthRecord(nonPrivilegedToken, None, testUsername, None, 3600, System.currentTimeMillis(), "", Some(false))
   private val privilegedToken = "0987654321"
-  private val privilegedAuthRecord = AuthRecord(privilegedToken, None, testUsername, None, 0, System.currentTimeMillis(), "", Some(true))
+  private val privilegedAuthRecord = AuthRecord(privilegedToken, None, testUsername, None, 3600, System.currentTimeMillis(), "", Some(true))
 
   val records = Map(
     nonPrivilegedToken -> nonPrivilegedAuthRecord,

--- a/src/test/scala/uk/gov/bis/levyApiMock/actions/AuthorizedActionBuilderTest.scala
+++ b/src/test/scala/uk/gov/bis/levyApiMock/actions/AuthorizedActionBuilderTest.scala
@@ -2,7 +2,7 @@ package uk.gov.bis.levyApiMock.actions
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, OptionValues, WordSpecLike}
-import uk.gov.bis.levyApiMock.data.GatewayUser
+import uk.gov.bis.levyApiMock.data.{GatewayUser, SystemTimeSource}
 import uk.gov.bis.levyApiMock.data.oauth2.AuthRecord
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -29,14 +29,14 @@ class AuthorizedActionBuilderTest extends WordSpecLike with Matchers with Option
 
   "non-privileged user with right empref" should {
     "have access" in {
-      val sut = new AuthorizedActionBuilder(empref1, new DummyAuthRecords(records), new DummyGatewayUsers(users))(ExecutionContext.global)
+      val sut = new AuthorizedActionBuilder(empref1, new DummyAuthRecords(records), new DummyGatewayUsers(users), new SystemTimeSource)(ExecutionContext.global)
       sut.validateToken(nonPrivilegedToken).futureValue.value shouldBe nonPrivilegedAuthRecord
     }
   }
 
   "privileged user with other empref" should {
     "have access" in {
-      val sut = new AuthorizedActionBuilder(empref2, new DummyAuthRecords(records), new DummyGatewayUsers(users))(ExecutionContext.global)
+      val sut = new AuthorizedActionBuilder(empref2, new DummyAuthRecords(records), new DummyGatewayUsers(users), new SystemTimeSource)(ExecutionContext.global)
       sut.validateToken(privilegedToken).futureValue.value shouldBe privilegedAuthRecord
     }
   }

--- a/src/test/scala/uk/gov/bis/levyApiMock/actions/StubAuthRecords.scala
+++ b/src/test/scala/uk/gov/bis/levyApiMock/actions/StubAuthRecords.scala
@@ -15,5 +15,5 @@ trait StubAuthRecords extends AuthRecordOps {
 
   override def create(record: AuthRecord)(implicit ec: ExecutionContext): Future[Unit] = ???
 
-  override def deleteExistingAndCreate(token: AuthRecord)(implicit ec: ExecutionContext): Future[Unit] = ???
+  override def deleteExistingAndCreate(existing: AuthRecord, created: AuthRecord)(implicit ec: ExecutionContext): Future[Unit] = ???
 }

--- a/src/test/scala/uk/gov/bis/levyApiMock/controllers/security/OAuth2ControllerSpec.scala
+++ b/src/test/scala/uk/gov/bis/levyApiMock/controllers/security/OAuth2ControllerSpec.scala
@@ -1,0 +1,91 @@
+package uk.gov.bis.levyApiMock.controllers.security
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{Matchers, OptionValues, WordSpecLike}
+import play.api.libs.json.{JsString, JsValue}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.bis.levyApiMock.auth.APIDataHandler
+import uk.gov.bis.levyApiMock.data.oauth2.AuthRecord
+import uk.gov.bis.levyApiMock.data.{Application, GatewayUser, MongoDate, SystemTimeSource}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class OAuth2ControllerSpec extends WordSpecLike with Matchers with ScalaFutures with OptionValues {
+  implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
+
+  val user1 = "user1"
+  val acesstoken1 = "acesstoken1"
+  val clientid1 = "clientid1"
+  val refreshtoken1 = "refreshtoken1"
+  val clientsecret1 = "clientsecret1"
+
+  "accessToken" should {
+    "issue a new access token and refresh token" in {
+      val mockAuthRecords = new MockAuthRecords
+
+      val dh = new APIDataHandler(DummyClients, mockAuthRecords, DummyAuthCodes, DummyGatewayUsers, new SystemTimeSource)
+      val controller = new OAuth2Controller(dh)
+      val request = FakeRequest().withFormUrlEncodedBody(
+        "grant_type" -> "refresh_token",
+        "client_id" -> clientid1,
+        "refresh_token" -> refreshtoken1,
+        "client_secret" -> clientsecret1
+      )
+
+      val result = controller.accessToken(request)
+      status(result) shouldBe OK
+
+      val resultMap = contentAsJson(result).validate[Map[String, JsValue]].asOpt.value
+      val deleteAuthRecord = mockAuthRecords.deletedAuthRecord.value
+      val createdAuthRecord = mockAuthRecords.createdAuthRecord.value
+
+      resultMap.get("access_token").value shouldBe JsString(createdAuthRecord.accessToken)
+      resultMap.get("refresh_token").value shouldBe JsString(createdAuthRecord.refreshToken.value)
+
+      createdAuthRecord.accessToken shouldNot be(deleteAuthRecord.accessToken)
+      createdAuthRecord.refreshToken.value shouldNot be(deleteAuthRecord.refreshToken.value)
+      createdAuthRecord.clientID shouldBe clientid1
+      createdAuthRecord.gatewayID shouldBe user1
+    }
+  }
+
+  object DummyClients extends StubClientOps {
+    val clients = Seq(Application("test", "appid1", clientid1, clientsecret1, "servertoken1", privilegedAccess = false))
+
+    override def forId(clientID: String)(implicit ec: ExecutionContext): Future[Option[Application]] = {
+      Future.successful(clients.find(_.clientID == clientID))
+    }
+  }
+
+  class MockAuthRecords extends StubAuthRecordOps {
+    var createdAuthRecord: Option[AuthRecord] = None
+    var deletedAuthRecord: Option[AuthRecord] = None
+
+    val records = Seq(
+      AuthRecord(acesstoken1, Some(refreshtoken1), user1, None, 3600, MongoDate.fromLong(0), clientid1, Some(false))
+    )
+
+    override def forRefreshToken(refreshToken: String)(implicit ec: ExecutionContext): Future[Option[AuthRecord]] = {
+      Future.successful(records.find(_.refreshToken === Some(refreshToken)))
+    }
+
+    override def deleteExistingAndCreate(existing: AuthRecord, created: AuthRecord)(implicit ec: ExecutionContext): Future[Unit] = {
+      deletedAuthRecord = Some(existing)
+      createdAuthRecord = Some(created)
+      Future.successful(())
+    }
+  }
+
+  object DummyAuthCodes extends StubAuthCodeOps
+
+  object DummyGatewayUsers extends StubGatewayUserOps {
+    val users = Seq(GatewayUser(user1, "password", "empref1", None, None))
+
+    override def forGatewayID(gatewayID: String)(implicit ec: ExecutionContext): Future[Option[GatewayUser]] = {
+      Future.successful(users.find(_.gatewayID === gatewayID))
+    }
+  }
+
+}

--- a/src/test/scala/uk/gov/bis/levyApiMock/controllers/security/StubAuthCodeOps.scala
+++ b/src/test/scala/uk/gov/bis/levyApiMock/controllers/security/StubAuthCodeOps.scala
@@ -1,0 +1,13 @@
+package uk.gov.bis.levyApiMock.controllers.security
+
+import uk.gov.bis.levyApiMock.data.{AuthCodeOps, AuthCodeRow}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait StubAuthCodeOps extends AuthCodeOps{
+  override def find(code: String)(implicit ec: ExecutionContext): Future[Option[AuthCodeRow]] = ???
+
+  override def delete(code: String)(implicit ec: ExecutionContext): Future[Int] = ???
+
+  override def create(code: String, gatewayUserId: String, redirectUri: String, clientId: String, scope: String)(implicit ec: ExecutionContext): Future[Int] = ???
+}

--- a/src/test/scala/uk/gov/bis/levyApiMock/controllers/security/StubAuthRecordOps.scala
+++ b/src/test/scala/uk/gov/bis/levyApiMock/controllers/security/StubAuthRecordOps.scala
@@ -1,0 +1,19 @@
+package uk.gov.bis.levyApiMock.controllers.security
+
+import uk.gov.bis.levyApiMock.data.oauth2.{AuthRecord, AuthRecordOps}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait StubAuthRecordOps extends AuthRecordOps {
+  override def forRefreshToken(refreshToken: String)(implicit ec: ExecutionContext): Future[Option[AuthRecord]] = ???
+
+  override def forAccessToken(accessToken: String)(implicit ec: ExecutionContext): Future[Option[AuthRecord]] = ???
+
+  override def find(accessToken: String)(implicit ec: ExecutionContext): Future[Option[AuthRecord]] = ???
+
+  override def find(gatewayId: String, clientId: Option[String])(implicit ec: ExecutionContext): Future[Option[AuthRecord]] = ???
+
+  override def create(record: AuthRecord)(implicit ec: ExecutionContext): Future[Unit] = ???
+
+  override def deleteExistingAndCreate(existing: AuthRecord, created: AuthRecord)(implicit ec: ExecutionContext): Future[Unit] = ???
+}

--- a/src/test/scala/uk/gov/bis/levyApiMock/controllers/security/StubClientOps.scala
+++ b/src/test/scala/uk/gov/bis/levyApiMock/controllers/security/StubClientOps.scala
@@ -1,0 +1,11 @@
+package uk.gov.bis.levyApiMock.controllers.security
+
+import uk.gov.bis.levyApiMock.data.{Application, ClientOps, TimeSource}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait StubClientOps extends ClientOps {
+  override def timeSource: TimeSource = ???
+
+  override def forId(clientID: String)(implicit ec: ExecutionContext): Future[Option[Application]] = ???
+}

--- a/src/test/scala/uk/gov/bis/levyApiMock/controllers/security/StubGatewayUserOps.scala
+++ b/src/test/scala/uk/gov/bis/levyApiMock/controllers/security/StubGatewayUserOps.scala
@@ -1,0 +1,13 @@
+package uk.gov.bis.levyApiMock.controllers.security
+
+import uk.gov.bis.levyApiMock.data.{GatewayUser, GatewayUserOps}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait StubGatewayUserOps extends GatewayUserOps{
+  override def forGatewayID(gatewayID: String)(implicit ec: ExecutionContext): Future[Option[GatewayUser]] = ???
+
+  override def forEmpref(empref: String)(implicit ec: ExecutionContext): Future[Option[GatewayUser]] = ???
+
+  override def validate(gatewayID: String, password: String)(implicit ec: ExecutionContext): Future[Option[GatewayUser]] = ???
+}


### PR DESCRIPTION
Properly check if access tokens have expired. When using a refresh token the old auth record is now deleted and a new value of the refresh token is generated. This matches the way the HMRC oAuth implementation works.